### PR TITLE
fix: save the DQN demo GIF in the chapter figures directory

### DIFF
--- a/content/docs/01-value-based/dqn/dqn.py
+++ b/content/docs/01-value-based/dqn/dqn.py
@@ -15,7 +15,7 @@ from torch import nn
 from torch.nn import functional as F
 
 
-GIF_PATH = pathlib.Path(__file__).parent.parent / "public" / "figures" / "chapter-1.6-dqn-cartpole-balance-demo.gif"
+GIF_PATH = pathlib.Path(__file__).parent / "figures" / "cartpole-demo.gif"
 
 
 class QNetwork(nn.Module):


### PR DESCRIPTION
## 问题

DQN 示例使用了旧的 GIF 输出路径，实际指向 `content/docs/01-value-based/public/figures/`，与当前章节资源目录不一致。

## 修改

将输出路径改为章节内的 `figures/cartpole-demo.gif`，与现有页面引用和 `sync-figures.mjs` 的同步规则保持一致。

## 验证
 - Python 语法检查通过。
 - 输出路径与现有资源、中英文章节引用一致。
 - 旧路径无法通过相同的目标路径断言。
 - `git diff --check` 通过。