### PR TITLE
feat: add a configurable KL penalty to the PPO example

### DIFF
--- a/content/docs/02-on-policy-policy-based/ppo/ppo.py
+++ b/content/docs/02-on-policy-policy-based/ppo/ppo.py
@@ -1,9 +1,11 @@
 """PPO-Clip on CartPole-v1 with GAE.
 
 Proximal Policy Optimization (Schulman et al., 2017) with the clipped surrogate
-objective. Each iteration: collect rollout under pi_old, compute GAE, then K
+objective and an optional fixed-coefficient KL penalty. Each iteration: collect rollout under pi_old, compute GAE, then K
 minibatch epochs of SGD on the joint policy + value loss.
 """
+
+import math
 
 import gymnasium as gym
 import matplotlib.pyplot as plt
@@ -85,7 +87,10 @@ class PPO:
         max_grad_norm: float,
         n_epochs: int,
         minibatch_size: int,
+        kl_coef: float = 0.0,
     ) -> None:
+        if not math.isfinite(kl_coef) or kl_coef < 0:
+            raise ValueError("kl_coef must be finite and non-negative")
         self.policy = PolicyNet(state_dim, hidden_dim, n_actions)
         self.value = ValueNet(state_dim, hidden_dim)
         params = list(self.policy.parameters()) + list(self.value.parameters())
@@ -97,6 +102,7 @@ class PPO:
         self.max_grad_norm = max_grad_norm
         self.n_epochs = n_epochs
         self.minibatch_size = minibatch_size
+        self.kl_coef = kl_coef
 
     @torch.no_grad()
     def take_action(self, state: np.ndarray) -> tuple[int, float, float]:
@@ -114,17 +120,23 @@ class PPO:
         return float(self.value(s).item())
 
     def update(self, transition_dict: dict) -> dict[str, float]:
-        """K epochs of minibatch SGD on the clipped PPO objective."""
+        """Update immediately after collection, before any other policy changes.
+
+        The synchronous training loop lets us snapshot pi_old on rollout states
+        here. Keep this snapshot fixed across every minibatch and epoch.
+        """
         states = transition_dict["states"]
         actions = transition_dict["actions"]
         old_log_probs = transition_dict["old_log_probs"]
         returns = transition_dict["returns"]
         advantages = transition_dict["advantages"]
         advantages = (advantages - advantages.mean()) / (advantages.std() + 1e-8)
+        with torch.no_grad():
+            old_logits = self.policy(states).detach().clone()
 
         n = states.size(0)
         idx = np.arange(n)
-        stats = {"policy_loss": 0.0, "value_loss": 0.0, "entropy": 0.0}
+        stats = {"policy_loss": 0.0, "value_loss": 0.0, "entropy": 0.0, "kl": 0.0}
         n_updates = 0
 
         for _ in range(self.n_epochs):
@@ -136,6 +148,8 @@ class PPO:
                 dist = torch.distributions.Categorical(logits=logits)
                 new_log_probs = dist.log_prob(actions[mb])
                 entropy = dist.entropy().mean()
+                old_dist = torch.distributions.Categorical(logits=old_logits[mb])
+                kl = torch.distributions.kl_divergence(old_dist, dist).mean()
 
                 ratio = torch.exp(new_log_probs - old_log_probs[mb])
                 adv_mb = advantages[mb]
@@ -146,7 +160,8 @@ class PPO:
                 values_pred = self.value(states[mb])
                 value_loss = F.mse_loss(values_pred, returns[mb])
 
-                loss = policy_loss + self.value_coef * value_loss - self.entropy_coef * entropy
+                loss = (policy_loss + self.value_coef * value_loss
+                        - self.entropy_coef * entropy + self.kl_coef * kl)
                 self.optimizer.zero_grad()
                 loss.backward()
                 nn.utils.clip_grad_norm_(
@@ -158,6 +173,7 @@ class PPO:
                 stats["policy_loss"] += float(policy_loss.item())
                 stats["value_loss"] += float(value_loss.item())
                 stats["entropy"] += float(entropy.item())
+                stats["kl"] += float(kl.item())
                 n_updates += 1
 
         for k in stats:
@@ -303,6 +319,7 @@ if __name__ == "__main__":
     clip_eps = 0.2
     value_coef = 0.5
     entropy_coef = 0.0
+    kl_coef = 0.1  # Illustrative fixed beta, not a tuned or adaptive coefficient.
     max_grad_norm = 0.5
     lr = 3e-4
 
@@ -321,6 +338,7 @@ if __name__ == "__main__":
         max_grad_norm=max_grad_norm,
         n_epochs=n_epochs,
         minibatch_size=minibatch_size,
+        kl_coef=kl_coef,
     )
 
     print(f"Training PPO on {env_id} for {n_iterations} iterations "

--- a/content/docs/02-on-policy-policy-based/ppo/test_ppo.py
+++ b/content/docs/02-on-policy-policy-based/ppo/test_ppo.py
@@ -1,0 +1,94 @@
+"""CPU regression tests: python -m unittest discover -s <this directory>."""
+
+import importlib.util
+import math
+from pathlib import Path
+import unittest
+from unittest.mock import patch
+
+import numpy as np
+import torch
+
+
+spec = importlib.util.spec_from_file_location("handbook_ppo", Path(__file__).with_name("ppo.py"))
+ppo = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(ppo)
+
+
+class KLPenaltyTests(unittest.TestCase):
+    def agent(self, coefficient=0.0):
+        torch.manual_seed(7)
+        return ppo.PPO(4, 2, 8, 0.02, 0.2, 0.5, 0.0, 100.0, 3, 4,
+                       kl_coef=coefficient)
+
+    def batch(self, agent):
+        states = torch.randn(8, 4)
+        actions = torch.arange(8) % 2
+        with torch.no_grad():
+            logs = torch.distributions.Categorical(logits=agent.policy(states)).log_prob(actions)
+        return dict(states=states, actions=actions, old_log_probs=logs,
+                    returns=torch.arange(8).float(), advantages=torch.arange(8).float())
+
+    def test_exact_forward_kl_and_frozen_reference(self):
+        agent = self.agent(0.1)
+        batch = self.batch(agent)
+        with torch.no_grad():
+            reference = agent.policy(batch['states']).log_softmax(-1)
+        calls = []
+        original = torch.distributions.kl_divergence
+
+        def checked(old, new):
+            self.assertFalse(old.logits.requires_grad)
+            self.assertTrue(new.logits.requires_grad)
+            # No shuffling below: the same two minibatches repeat each epoch.
+            offset = (len(calls) % 2) * 4
+            torch.testing.assert_close(old.logits, reference[offset:offset + 4])
+            actual = original(old, new)
+            expected = (old.probs * (old.logits - new.logits)).sum(-1)
+            torch.testing.assert_close(actual, expected)
+            calls.append(actual.detach())
+            return actual
+
+        with patch.object(np.random, 'shuffle'), patch.object(
+            torch.distributions, 'kl_divergence', side_effect=checked
+        ):
+            stats = agent.update(batch)
+        self.assertEqual(len(calls), 6)
+        torch.testing.assert_close(calls[0], torch.zeros(4))
+        self.assertGreater(stats['kl'], 0)
+        self.assertTrue(all(math.isfinite(v) for v in stats.values()))
+
+    def test_penalty_changes_update_and_zero_disables_it(self):
+        def run(coefficient, suppress=False):
+            agent = self.agent(coefficient)
+            batch = self.batch(agent)
+            original = torch.distributions.kl_divergence
+            with patch.object(np.random, 'shuffle'), patch.object(
+                torch.distributions, 'kl_divergence',
+                side_effect=lambda p, q: original(p, q) * (0 if suppress else 1)
+            ):
+                agent.update(batch)
+            return torch.cat([p.detach().flatten() for p in agent.policy.parameters()])
+
+        baseline = run(0.0)
+        torch.testing.assert_close(baseline, run(0.0, suppress=True))
+        self.assertFalse(torch.allclose(baseline, run(10.0)))
+
+    def test_invalid_coefficients(self):
+        for value in [-1.0, float('nan'), float('inf')]:
+            with self.subTest(value=value), self.assertRaises(ValueError):
+                self.agent(value)
+
+    def test_cartpole_smoke(self):
+        agent = self.agent(0.1)
+        env = ppo.gym.make('CartPole-v1')
+        try:
+            ppo.train(env, agent, n_iterations=2, rollout_steps=16,
+                      gamma=0.99, gae_lambda=0.95, seed=7)
+            self.assertTrue(all(torch.isfinite(p).all() for p in agent.policy.parameters()))
+        finally:
+            env.close()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION

## 背景

PPO 章节给出的目标函数包含 KL penalty，并明确提到示例代码保留了这一项。但 `ppo.py` 原来的损失只包含 clipped policy loss、value loss 和 entropy bonus，没有对应的 KL 项。

## 实现

新增 `kl_coef` 参数，最终最小化的损失为：

    loss = policy_loss
        + value_coef * value_loss
        - entropy_coef * entropy
        + kl_coef * KL(old_policy || current_policy)

  KL 的方向与章节公式一致。CartPole 使用离散动作策略，因此这里通过两个 Categorical 分布，对所有动作计算精确 KL，再对 minibatch 中的状态取平均；不是只根据采样动作的 log probability 估计 KL。

旧策略的 logits 在 `update()` 开始、第一次优化之前保存，并从计算图中分离。在后续所有 minibatch 和 epoch 中都使用同一份快照，避免 KL 的参考策略随更新一起变化。梯度只通过当前策略传播。


## 参数和行为

- `kl_coef` 默认是 `0.0`，保留原调用方式以及不带 KL penalty 的优化目标。
- 可运行示例显式设置 `kl_coef = 0.1`，用于演示这一项；该值没有经过性能调优。
- `update()` 返回的统计信息新增 `kl`，记录各 minibatch 更新前的平均 KL，不代表整个更新结束后的最终 KL。


## 验证

新增 4 项 CPU 回归测试，覆盖：

- KL 结果与 `sum(p_old * (log p_old - log p_new))` 一致，方向为旧策略到新策略。
- 第一次优化前 KL 为零；策略更新后 KL 非零，旧分布在跨 minibatch、跨 epoch 更新时保持不变且不参与梯度计算。
- 非零系数确实影响策略参数更新；系数为零时，将 KL 项置零不改变更新结果。

运行命令：

    MPLBACKEND=Agg OMP_NUM_THREADS=1 python -m unittest discover \
       -s content/docs/02-on-policy-policy-based/ppo \
       -p test_ppo.py -v

在安装了 PyTorch、Gymnasium、NumPy 和 Matplotlib 的环境中，4 项测试通过；`git diff --check` 通过。